### PR TITLE
YRDropdownView can compile in non-ARC projects

### DIFF
--- a/YRDropdownView/YRDropdownView.h
+++ b/YRDropdownView/YRDropdownView.h
@@ -34,8 +34,13 @@ typedef void (^YRTapBlock)(void);
 @property (copy) NSString *titleText;
 @property (copy) NSString *detailText;
 
+#if !(__has_feature(objc_arc))
+@property (nonatomic, retain) UIImage *accessoryImage;
+@property (nonatomic, retain) UIImage *backgroundImage;
+#else
 @property (nonatomic, strong) UIImage *accessoryImage;
 @property (nonatomic, strong) UIImage *backgroundImage;
+#endif
 
 @property (assign) float minHeight;
 @property (retain) UIColor *titleLabelColor;

--- a/YRDropdownView/YRDropdownView.m
+++ b/YRDropdownView/YRDropdownView.m
@@ -522,6 +522,16 @@ static YRDropdownView *currentDropdown = nil;
     }
 }
 
+#if !(__has_feature(objc_arc))
+- (void)dealloc {
+	self.accessoryImage = nil;
+	self.backgroundImage = nil;
+	self.titleLabelColor = nil;
+	self.detailLabelColor = nil;
+    [super dealloc];
+}
+#endif
+
 @end
 
 


### PR DESCRIPTION
Declared non-ARC versions of accessoryImage and backgroundImage properties so the class YRDropdownView compiles.
