### PR TITLE
Changed LineBreak mode to get rid of a warning in Xcode.

### DIFF
--- a/YRDropdownExample/YRDropdownView/YRDropdownView.m
+++ b/YRDropdownExample/YRDropdownView/YRDropdownView.m
@@ -19,7 +19,7 @@
 - (void)sizeToFitFixedWidth:(CGFloat)fixedWidth
 {
     self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, fixedWidth, 0);
-    self.lineBreakMode = UILineBreakModeWordWrap;
+    self.lineBreakMode = NSLineBreakByWordWrapping;
     self.numberOfLines = 0;
     [self sizeToFit];
 }


### PR DESCRIPTION
This was deprecated in iOS 6.0, and it causes a warning in Xcode.
